### PR TITLE
fix: Support namespace when defined in info.xml

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -73,6 +73,11 @@ if (file_exists($infoXMLPath)) {
 
 	$appIsCore = false;
 	$appID = (string)$xml->id;
+	if ($xml->namespace) {
+		$readableAppID = (string)$xml->namespace;
+	} else {
+		$readableAppID = Helpers::generateReadableAppID($appID);
+	}
 	$appSummary = (string)$xml->summary;
 	$appVersion = (string)$xml->version;
 	$appLicence = (string)$xml->licence;
@@ -91,12 +96,12 @@ if (file_exists($infoXMLPath)) {
 
 	$appIsCore = true;
 	$appID = "core";
+	$readableAppID = "Core";
 	$appSummary = "Core functionality of Nextcloud";
 	$appVersion = $OC_VersionString;
 	$appLicence = "agpl";
 }
 
-$readableAppID = Helpers::generateReadableAppID($appID);
 $sourceDir = $appIsCore ? $dir : $dir . "/lib";
 $appinfoDir = $appIsCore ? $dir : $dir . "/appinfo";
 


### PR DESCRIPTION
Fix #11 

### Talk with this patch

```
$ ~/Repositories/openapi-extractor/generate-spec 
Info: app: Extracting OpenAPI spec for spreed 18.0.0-dev.6
PHP Fatal error:  Uncaught Exception: Error: Response definitions: Type alias 'SpreedRoomShare' has to start with 'Talk'
 in /home/nickv/Nextcloud/Repositories/openapi-extractor/src/Logger.php:33
Stack trace:
#0 /home/nickv/Nextcloud/Repositories/openapi-extractor/generate-spec(139): OpenAPIExtractor\Logger::error()
#1 {main}
  thrown in /home/nickv/Nextcloud/Repositories/openapi-extractor/src/Logger.php on line 33
```

### Fallback retained
Since namespace is optional, I added a check and fallback for the current behaviour. After removing the namespace line in Talk it "worked again" using "Spreed":
```
$ ~/Repositories/openapi-extractor/generate-spec 
Info: app: Extracting OpenAPI spec for spreed 18.0.0-dev.6
Info: Avatar#uploadAvatar: Route generated
Info: Avatar#emojiAvatar: Route generated
Info: Avatar#getAvatar: Route generated
Info: Avatar#getAvatarDark: Route generated
Info: Avatar#deleteAvatar: Route generated
```