### PR TITLE
fix: Do not convert union types to string

### DIFF
--- a/src/OpenApiType.php
+++ b/src/OpenApiType.php
@@ -53,7 +53,6 @@ class OpenApiType {
 		$asContentString = $isParameter && (
 				$this->type == "object" ||
 				$this->ref !== null ||
-				$this->oneOf !== null ||
 				$this->anyOf !== null ||
 				$this->allOf !== null);
 		if ($asContentString) {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/openapi-extractor/issues/36

Merging the enums is necessary because otherwise every sub type of the union type will be it's own enum with only one possible value.