### PR TITLE
feat: Prevent mixed in unions and intersections

### DIFF
--- a/src/OpenApiType.php
+++ b/src/OpenApiType.php
@@ -212,6 +212,9 @@ class OpenApiType {
 					$nullable = true;
 					continue;
 				}
+				if (($type instanceof IdentifierTypeNode || $type instanceof Identifier) && $type->name == "mixed") {
+					Logger::error($context, "Unions and intersections should not contain 'mixed'");
+				}
 				$items[] = self::resolve($context, $definitions, $type);
 			}
 


### PR DESCRIPTION
Closes https://github.com/nextcloud/openapi-extractor/issues/12

`mixed` is illegal because it will absorb every other type and lead to invalid specifications. No changes required in any of the apps that currently support openapi-extractor.