### PR TITLE
fix(logger): Show full message when throwing LoggerException

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -2,8 +2,6 @@
 
 namespace OpenAPIExtractor;
 
-use Exception;
-
 class Logger {
 	static bool $exitOnError = true;
 

--- a/src/LoggerException.php
+++ b/src/LoggerException.php
@@ -12,4 +12,8 @@ class LoggerException extends Exception {
 	) {
 		parent::__construct($message);
 	}
+
+	public function __toString(): string {
+		return $this->level->value . ": " . $this->context . ": " . $this->message;
+	}
 }


### PR DESCRIPTION
Since https://github.com/nextcloud/openapi-extractor/commit/80cfa10060e41060413d18820d0359cae5a9c056 the exceptions that were thrown didn't show the full message (including level and context) anymore.