### PR TITLE
fix(merge-specs): Remove accidental value casting

### DIFF
--- a/merge-specs
+++ b/merge-specs
@@ -97,8 +97,8 @@ function loadSpec(string $path): array {
 
 function rewriteRefs(array $spec): array {
 	$readableAppID = Helpers::generateReadableAppID($spec["info"]["title"]);
-	array_walk_recursive($spec, function (string &$item, string $key) use ($readableAppID) {
-		if ($key == "\$ref" && $item != "#/components/schemas/OCSMeta") {
+	array_walk_recursive($spec, function (mixed &$item, string $key) use ($readableAppID) {
+		if ($key === '$ref' && $item !== '#/components/schemas/OCSMeta') {
 			$item = str_replace("#/components/schemas/", "#/components/schemas/" . $readableAppID, $item);
 		}
 	});


### PR DESCRIPTION
https://github.com/nextcloud/openapi-extractor/pull/57 introduced this and with it all map values were converted to string automatically which is wrong.