### PR TITLE
fix: Stop renaming parts of the operationId

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -584,8 +584,7 @@ foreach ($routes as $route) {
 		);
 	}
 
-	$operationId = [$route->tag];
-	$operationId = array_merge($operationId, array_map(fn (string $s) => Helpers::mapVerb(strtolower($s)), Helpers::splitOnUppercaseFollowedByNonUppercase($route->methodName)));
+	$operationId = [$route->tag, ...Helpers::splitOnUppercaseFollowedByNonUppercase($route->methodName)];
 	if ($route->postfix != null) {
 		$operationId[] = $route->postfix;
 	}
@@ -605,7 +604,7 @@ foreach ($routes as $route) {
 	}
 
 	$operation = array_merge(
-		["operationId" => implode("-", $operationId)],
+		["operationId" => strtolower(implode("-", $operationId))],
 		$route->controllerMethod->summary != null ? ["summary" => $route->controllerMethod->summary] : [],
 		count($route->controllerMethod->description) > 0 ? ["description" => implode("\n", $route->controllerMethod->description)] : [],
 		$route->controllerMethod->isDeprecated ? ["deprecated" => true] : [],

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -50,13 +50,6 @@ class Helpers {
 		return preg_split('/(?=[A-Z][^A-Z])/', $str, -1, PREG_SPLIT_NO_EMPTY);
 	}
 
-	public static function mapVerb(string $verb): string {
-		return match ($verb) {
-			"index" => "list",
-			default => $verb,
-		};
-	}
-
 	public static function mergeSchemas(array $schemas): mixed {
 		if (!in_array(true, array_map(fn ($schema) => is_array($schema), $schemas))) {
 			$results = array_values(array_unique($schemas));


### PR DESCRIPTION
At one point I thought it would be a good idea to rename `index` to `list` because it is more intuitive, but it can have unintended side effects, so we should stop doing that.