### PR TITLE
feat(generate-spec): Add a little done message when the spec is generated

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -723,3 +723,5 @@ if ($useTags) {
 }
 
 file_put_contents($out, json_encode($openapi, Helpers::jsonFlags()));
+
+Logger::info("app", "Generated ". count($routes). " routes!");


### PR DESCRIPTION
Now that we don't print a lot of messages anymore it's good to show a message when done so it's clear that there was no problem.