### PR TITLE
fix(CI): Don't cancel "in Repositories" from the normal testing job

### DIFF
--- a/.github/workflows/test-repositories.yml
+++ b/.github/workflows/test-repositories.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: openapi-${{ github.head_ref || github.run_id }}
+  group: openapi-repositories-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/openapi-extractor/pull/24 to avoid the self-canceling CI workflows.