### PR TITLE
fix(routing): Extract routes even with multiple registerRoutes calls

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -29,8 +29,8 @@ class Route {
 			}
 			return include($path);
 		} elseif (str_contains($content, "registerRoutes")) {
-			preg_match("/registerRoutes\(.*?\\\$this,.*?(\[[^;]*)\);/s", $content, $matches);
-			return self::includeRoutes("<?php\nreturn " . $matches[1] . ";");
+			preg_match_all("/registerRoutes\(.*?\\\$this,.*?(\[[^;]*)\);/s", $content, $matches);
+			return array_merge(...array_map(fn (string $match) => self::includeRoutes("<?php\nreturn " . $match . ";"), $matches[1]));
 		} else {
 			Logger::panic("Routes", "Unknown routes.php format");
 		}


### PR DESCRIPTION
Happens in https://github.com/nextcloud/server/blob/master/apps/user_ldap/appinfo/routes.php, but in this particular case all the newly discovered routes have to be ignored.