### PR TITLE
fix(Helpers): Fix ref collection

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -253,25 +253,11 @@ class Helpers {
 
 	public static function collectUsedRefs(array $data): array {
 		$refs = [];
-		if (isset($data['$ref'])) {
-			$refs[] = [$data['$ref']];
-		}
-
-		foreach (['allOf', 'oneOf', 'anyOf', 'properties', 'additionalProperties'] as $group) {
-			if (!isset($data[$group]) || !is_array($data[$group])) {
-				continue;
+		array_walk_recursive($data, function ($value, $key) use (&$refs) {
+			if ($key === '$ref') {
+				$refs[] = $value;
 			}
-
-			foreach ($data[$group] as $property) {
-				if (is_array($property)) {
-					$refs[] = self::collectUsedRefs($property);
-				}
-			}
-		}
-
-		if (isset($data['items'])) {
-			$refs[] = self::collectUsedRefs($data['items']);
-		}
-		return array_merge(...$refs);
+		});
+		return $refs;
 	}
 }


### PR DESCRIPTION
Broken after https://github.com/nextcloud/openapi-extractor/pull/24.

The problem is that allOf, oneOf and anyOf contain lists of schemas, while properties contains a map of schemas and additionalProperties is a schema directly. Using recursive walk solves this and will not encounter problems in the future.

The dashboard app is affected (https://github.com/nextcloud/server/pull/42888/files#diff-34caa6070d1d05fddc37174348f4f3a601f7d9a3c01816e68c1303b449cd575b)