### PR TITLE
fix(scopes): Add scope suffix even for single scopes

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -783,7 +783,7 @@ if (!$hasSingleScope) {
 foreach ($scopePaths as $scope => $paths) {
 	$openapiScope = $openapi;
 
-	$scopeSuffix = ($hasSingleScope || $scope === 'default') ? '' : '-' . $scope;
+	$scopeSuffix = $scope === 'default' ? '' : '-' . $scope;
 	$openapiScope['info']['title'] .= $scopeSuffix;
 	$openapiScope['paths'] = $paths;
 


### PR DESCRIPTION
When an app has all routes under a single scope we still want to have suffix (unless it is default ofc).
Affected apps are cloud_federation_api (where everything should be federation) and settings, updatenotification and user_ldap where everything is administration.