### PR TITLE
fix(helpers): Fix parsing arrays

### DIFF
--- a/src/ControllerMethodParameter.php
+++ b/src/ControllerMethodParameter.php
@@ -2,14 +2,7 @@
 
 namespace OpenAPIExtractor;
 
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
-use PhpParser\Node\Expr\ConstFetch;
-use PhpParser\Node\Expr\UnaryMinus;
 use PhpParser\Node\Param;
-use PhpParser\Node\Scalar\LNumber;
-use PhpParser\Node\Scalar\String_;
 
 class ControllerMethodParameter {
 	public OpenApiType $type;
@@ -22,45 +15,7 @@ class ControllerMethodParameter {
 		}
 		if ($methodParameter->default != null) {
 			$this->type->hasDefaultValue = true;
-			$this->type->defaultValue = self::exprToValue($context, $methodParameter->default);
+			$this->type->defaultValue = Helpers::exprToValue($context, $methodParameter->default);
 		}
-	}
-
-	private static function exprToValue(string $context, Expr $expr): mixed {
-		if ($expr instanceof ConstFetch) {
-			$value = $expr->name->getLast();
-			return match ($value) {
-				"null" => null,
-				"true" => true,
-				"false" => false,
-				default => Logger::panic($context, "Unable to evaluate constant value '" . $value . "'"),
-			};
-		}
-		if ($expr instanceof String_) {
-			return $expr->value;
-		}
-		if ($expr instanceof LNumber) {
-			return intval($expr->value);
-		}
-		if ($expr instanceof UnaryMinus) {
-			return -self::exprToValue($context, $expr->expr);
-		}
-		if ($expr instanceof Array_) {
-			$values = array_map(fn (ArrayItem $item): mixed => self::exprToValue($context, $item), $expr->items);
-			$filteredValues = array_filter($values, fn (mixed $value) => $value !== null);
-			if (count($filteredValues) != count($values)) {
-				return null;
-			}
-			return $values;
-		}
-		if ($expr instanceof ArrayItem) {
-			return self::exprToValue($context, $expr->value);
-		}
-		if ($expr instanceof Expr\ClassConstFetch || $expr instanceof Expr\BinaryOp) {
-			// Not supported
-			return null;
-		}
-
-		Logger::panic($context, "Unable to evaluate expression '" . get_class($expr) . "'");
 	}
 }

--- a/src/ControllerMethodParameter.php
+++ b/src/ControllerMethodParameter.php
@@ -14,8 +14,12 @@ class ControllerMethodParameter {
 			$this->type = OpenApiType::resolve($context, $definitions, $methodParameter->type);
 		}
 		if ($methodParameter->default != null) {
-			$this->type->hasDefaultValue = true;
-			$this->type->defaultValue = Helpers::exprToValue($context, $methodParameter->default);
+			try {
+				$this->type->defaultValue = Helpers::exprToValue($context, $methodParameter->default);
+				$this->type->hasDefaultValue = true;
+			} catch (UnsupportedExprException $e) {
+				Logger::debug($context, $e);
+			}
 		}
 	}
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\UnaryMinus;
@@ -286,15 +285,16 @@ class Helpers {
 			return -self::exprToValue($context, $expr->expr);
 		}
 		if ($expr instanceof Array_) {
-			$values = array_map(static fn (ArrayItem $item): mixed => self::exprToValue($context, $item), $expr->items);
-			$filteredValues = array_filter($values, static fn (mixed $value) => $value !== null);
-			if (count($filteredValues) !== count($values)) {
-				return null;
+			$array = [];
+			foreach ($expr->items as $item) {
+				$value = self::exprToValue($context, $item->value);
+				if ($item->key !== null) {
+					$array[self::exprToValue($context, $item->key)] = $value;
+				} else {
+					$array[] = $value;
+				}
 			}
-			return $values;
-		}
-		if ($expr instanceof ArrayItem) {
-			return self::exprToValue($context, $expr->value);
+			return $array;
 		}
 		if ($expr instanceof Expr\ClassConstFetch || $expr instanceof Expr\BinaryOp) {
 			// Not supported

--- a/src/UnsupportedExprException.php
+++ b/src/UnsupportedExprException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OpenAPIExtractor;
+
+use Exception;
+use PhpParser\Node\Expr;
+
+class UnsupportedExprException extends Exception {
+	public function __construct(
+		public Expr $expr,
+		public string $context,
+	) {
+		parent::__construct($this->context . ': Unable to parse Expr: ' . get_class($this->expr));
+	}
+}

--- a/tests/appinfo/routes.php
+++ b/tests/appinfo/routes.php
@@ -61,5 +61,7 @@ return [
 		['name' => 'Settings#stringValueParameter', 'url' => '/api/{apiVersion}/string-value', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#intValueParameter', 'url' => '/api/{apiVersion}/int-value', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#numericParameter', 'url' => '/api/{apiVersion}/numeric', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#arrayListParameter', 'url' => '/api/{apiVersion}/array-list', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#arrayKeyedParameter', 'url' => '/api/{apiVersion}/array-keyed', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 	],
 ];

--- a/tests/lib/Controller/SettingsController.php
+++ b/tests/lib/Controller/SettingsController.php
@@ -386,4 +386,28 @@ class SettingsController extends OCSController {
 	public function numericParameter(mixed $value): DataResponse {
 		return new DataResponse();
 	}
+
+	/**
+	 * A route with list
+	 *
+	 * @param list<string> $value Some array value
+	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
+	 *
+	 * 200: Admin settings updated
+	 */
+	public function arrayListParameter(array $value = ['test']): DataResponse {
+		return new DataResponse();
+	}
+
+	/**
+	 * A route with keyed array
+	 *
+	 * @param array<string, string> $value Some array value
+	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
+	 *
+	 * 200: Admin settings updated
+	 */
+	public function arrayKeyedParameter(array $value = ['test' => 'abc']): DataResponse {
+		return new DataResponse();
+	}
 }

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -2161,6 +2161,172 @@
                     }
                 }
             }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/array-list": {
+            "post": {
+                "operationId": "settings-array-list-parameter",
+                "summary": "A route with list",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "value[]",
+                        "in": "query",
+                        "description": "Some array value",
+                        "schema": {
+                            "type": "array",
+                            "default": [
+                                "test"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Admin settings updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/array-keyed": {
+            "post": {
+                "operationId": "settings-array-keyed-parameter",
+                "summary": "A route with keyed array",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Some array value",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Admin settings updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "tags": []

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -2289,6 +2289,172 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/array-list": {
+            "post": {
+                "operationId": "settings-array-list-parameter",
+                "summary": "A route with list",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "value[]",
+                        "in": "query",
+                        "description": "Some array value",
+                        "schema": {
+                            "type": "array",
+                            "default": [
+                                "test"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Admin settings updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/array-keyed": {
+            "post": {
+                "operationId": "settings-array-keyed-parameter",
+                "summary": "A route with keyed array",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "description": "Some array value",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Admin settings updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/default-admin-overwritten": {
             "post": {
                 "operationId": "admin_settings-moved-to-default-scope",


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/openapi-extractor/pull/73 and added tests.
When a parameter had an array as default value it wasn't parsed correctly.
The output of the spec still says the type is string, but that has to do with https://github.com/nextcloud/openapi-extractor/issues/88#issuecomment-1908557979 and can't be fixed that easily here.