### PR TITLE
fix: Load controllers in a deterministic order

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -240,12 +240,17 @@ $controllers = [];
 $controllersDir = $sourceDir . "/Controller";
 if (file_exists($controllersDir)) {
 	$dir = new DirectoryIterator($controllersDir);
+	$controllerFiles = [];
 	foreach ($dir as $file) {
 		$filePath = $file->getPathname();
 		if (!str_ends_with($filePath, "Controller.php")) {
 			continue;
 		}
+		$controllerFiles[] = $filePath;
+	}
+	sort($controllerFiles);
 
+	foreach ($controllerFiles as $filePath) {
 		$controllers[basename($filePath, "Controller.php")] = $astParser->parse(file_get_contents($filePath));
 	}
 }


### PR DESCRIPTION
Will fix the CI failure in https://github.com/nextcloud/server/actions/runs/7987586055/job/21810358990?pr=42801 which is caused by the controllers being read in a different order on my machine vs. the CI.
I already had this problem once with the capabilities files, so this was easy to figure out...