### PR TITLE
feat(scopes): Limit tag names

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -240,7 +240,12 @@ class Helpers {
 
 						foreach ($arg->value->items as $item) {
 							if ($item?->value instanceof String_) {
-								$foundTags[] = $item->value->value;
+								$tag = $item->value->value;
+								$pattern = "/^[0-9a-zA-Z_-]+$/";
+								if (!preg_match($pattern, $tag)) {
+									Logger::error($routeName, 'Tag "' . $tag . '" has to match pattern "' . $pattern . '"');
+								}
+								$foundTags[] = $tag;
 							}
 						}
 					}


### PR DESCRIPTION
Closes https://github.com/nextcloud/openapi-extractor/issues/99

Tags should be limited to certain characters to avoid developers using strange things that could break generators.