### PR TITLE
fix(docs): Diff non-default scoped specs in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
       - name: OpenAPI checker
         run: |
           composer exec generate-spec
-          if [ -n "$(git status --porcelain openapi.json)" ]; then
+          if [ -n "$(git status --porcelain openapi*.json)" ]; then
             git diff
             exit 1
           fi


### PR DESCRIPTION
Fixes https://github.com/nextcloud/openapi-extractor/issues/96