### PR TITLE
refactor: Stop using array_merge to create associative arrays

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -620,12 +620,12 @@ foreach ($routes as $scope => $scopeRoutes) {
 			$parameter = [
 				"name" => $urlParameter,
 				"in" => "path",
+				"required" => true,
+				"schema" => $schema,
 			];
 			if ($description !== null) {
 				$parameter["description"] = $description;
 			}
-			$parameter["required"] = true;
-			$parameter["schema"] = $schema;
 
 			$pathParameters[] = $parameter;
 		}

--- a/generate-spec
+++ b/generate-spec
@@ -617,17 +617,17 @@ foreach ($routes as $scope => $scopeRoutes) {
 				$schema["default"] = $route->defaults[$urlParameter];
 			}
 
-			$pathParameters[] = array_merge(
-				[
-					"name" => $urlParameter,
-					"in" => "path",
-				],
-				$description != null ? ["description" => $description] : [],
-				[
-					"required" => true,
-					"schema" => $schema,
-				],
-			);
+			$parameter = [
+				"name" => $urlParameter,
+				"in" => "path",
+			];
+			if ($description !== null) {
+				$parameter["description"] = $description;
+			}
+			$parameter["required"] = true;
+			$parameter["schema"] = $schema;
+
+			$pathParameters[] = $parameter;
 		}
 
 		$queryParameters = [];
@@ -688,25 +688,24 @@ foreach ($routes as $scope => $scopeRoutes) {
 				}
 			}
 
-			$mergedResponses[$statusCode] = array_merge(
-				[
-					"description" => array_key_exists($statusCode, $route->controllerMethod->responseDescription) ? $route->controllerMethod->responseDescription[$statusCode] : "",
-				],
-				count($headers) > 0 ? [
-					"headers" => array_combine(
-						array_keys($headers),
-						array_map(
-							fn (OpenApiType $type) => [
-								"schema" => $type->toArray($openapiVersion),
-							],
-							array_values($headers),
-						),
+			$response = [
+				"description" => array_key_exists($statusCode, $route->controllerMethod->responseDescription) ? $route->controllerMethod->responseDescription[$statusCode] : "",
+			];
+			if (count($headers) > 0) {
+				$response["headers"] = array_combine(
+					array_keys($headers),
+					array_map(
+						fn (OpenApiType $type) => [
+							"schema" => $type->toArray($openapiVersion),
+						],
+						array_values($headers),
 					),
-				] : [],
-				count($mergedContentTypeResponses) > 0 ? [
-					"content" => $mergedContentTypeResponses,
-				] : [],
-			);
+				);
+			}
+			if (count($mergedContentTypeResponses) > 0) {
+				$response["content"] = $mergedContentTypeResponses;
+			}
+			$mergedResponses[$statusCode] = $response;
 		}
 
 		$operationId = [...$route->tags, ...Helpers::splitOnUppercaseFollowedByNonUppercase($route->methodName)];
@@ -728,39 +727,58 @@ foreach ($routes as $scope => $scopeRoutes) {
 			$security[] = ["basic_auth" => []];
 		}
 
-		$operation = array_merge(
-			["operationId" => strtolower(implode("-", $operationId))],
-			$route->controllerMethod->summary != null ? ["summary" => $route->controllerMethod->summary] : [],
-			count($route->controllerMethod->description) > 0 ? ["description" => implode("\n", $route->controllerMethod->description)] : [],
-			$route->controllerMethod->isDeprecated ? ["deprecated" => true] : [],
-			$useTags ? ["tags" => $route->tags] : [],
-			count($security) > 0 ? ["security" => $security] : [],
-			count($queryParameters) > 0 || count($pathParameters) > 0 || $route->isOCS ? [
-				"parameters" => array_merge(
-					array_map(fn (ControllerMethodParameter $parameter) => array_merge(
-						[
-							"name" => $parameter->name . ($parameter->type->type == "array" ? "[]" : ""),
-							"in" => "query",
-						],
-						$parameter->docType != null && $parameter->docType->description != "" ? ["description" => Helpers::cleanDocComment($parameter->docType->description)] : [],
-						!$parameter->type->nullable && !$parameter->type->hasDefaultValue ? ["required" => true] : [],
-						["schema" => $parameter->type->toArray($openapiVersion, true),],
-					), $queryParameters),
-					$pathParameters,
-					$route->isOCS ? [[
-						"name" => "OCS-APIRequest",
-						"in" => "header",
-						"description" => "Required to be true for the API request to pass",
-						"required" => true,
-						"schema" => [
-							"type" => "boolean",
-							"default" => true,
-						],
-					]] : [],
-				),
-			] : [],
-			["responses" => $mergedResponses],
-		);
+		$operation = [
+			"operationId" => strtolower(implode("-", $operationId)),
+		];
+		if ($route->controllerMethod->summary !== null) {
+			$operation["summary"] = $route->controllerMethod->summary;
+		}
+		if (count($route->controllerMethod->description) > 0) {
+			$operation["description"] = implode("\n", $route->controllerMethod->description);
+		}
+		if ($route->controllerMethod->isDeprecated) {
+			$operation["deprecated"] = true;
+		}
+		if ($useTags) {
+			$operation["tags"] = $route->tags;
+		}
+		if (count($security) > 0) {
+			$operation["security"] = $security;
+		}
+		if (count($queryParameters) > 0 || count($pathParameters) > 0 || $route->isOCS) {
+			$parameters = [
+				...array_map(static function (ControllerMethodParameter $parameter) use ($openapiVersion) {
+					$out = [
+						"name" => $parameter->name . ($parameter->type->type === "array" ? "[]" : ""),
+						"in" => "query",
+					];
+					if ($parameter->docType !== null && $parameter->docType->description !== "") {
+						$out["description"] = Helpers::cleanDocComment($parameter->docType->description);
+					}
+					if (!$parameter->type->nullable && !$parameter->type->hasDefaultValue) {
+						$out["required"] = true;
+					}
+					$out["schema"] = $parameter->type->toArray($openapiVersion, true);
+
+					return $out;
+				}, $queryParameters),
+				...$pathParameters,
+			];
+			if ($route->isOCS) {
+				$parameters[] = [
+					"name" => "OCS-APIRequest",
+					"in" => "header",
+					"description" => "Required to be true for the API request to pass",
+					"required" => true,
+					"schema" => [
+						"type" => "boolean",
+						"default" => true,
+					],
+				];
+			}
+			$operation["parameters"] = $parameters;
+		}
+		$operation["responses"] = $mergedResponses;
 
 		$scopePaths[$scope] ??= [];
 		$scopePaths[$scope][$route->url] ??= [];

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -42,11 +42,14 @@ class Helpers {
 			"agpl" => "AGPL-3.0-only",
 			default => Logger::panic("license", "Unable to convert " . $license . " to SPDX identifier"),
 		};
-		return array_merge([
+
+		$out = [
 			"name" => "agpl",
-		],
-			version_compare($openapiVersion, "3.1.0", ">=") ? ["identifier" => $identifier] : [],
-		);
+		];
+		if (version_compare($openapiVersion, "3.1.0", ">=")) {
+			$out["identifier"] = $identifier;
+		}
+		return $out;
 	}
 
 	public static function jsonFlags(): int {


### PR DESCRIPTION
The previous code was not really readable and probably didn't perform well.