### PR TITLE
fix: Move all parameters from query to JSON body

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -151,7 +151,7 @@ if (file_exists($definitionsPath)) {
 		}
 	}
 	foreach (array_keys($definitions) as $name) {
-		$schemas[Helpers::cleanSchemaName($name)] = OpenApiType::resolve("Response definitions", $definitions, $definitions[$name])->toArray($openapiVersion);
+		$schemas[Helpers::cleanSchemaName($name)] = OpenApiType::resolve("Response definitions", $definitions, $definitions[$name])->toArray();
 	}
 } else {
 	Logger::debug("Response definitions", "No response definitions were loaded");
@@ -217,7 +217,7 @@ foreach ($capabilitiesFiles as $path) {
 			continue;
 		}
 
-		$schema = $type->toArray($openapiVersion);
+		$schema = $type->toArray();
 
 		if ($implementsPublicCapability) {
 			$publicCapabilities = $publicCapabilities == null ? $schema : Helpers::mergeSchemas([$publicCapabilities, $schema]);
@@ -596,7 +596,7 @@ foreach ($routes as $scope => $scopeRoutes) {
 					continue;
 				}
 
-				$schema = $parameter->type->toArray($openapiVersion, true);
+				$schema = $parameter->type->toArray(true);
 				$description = $parameter?->docType != null && $parameter->docType->description != "" ? Helpers::cleanDocComment($parameter->docType->description) : null;
 			} else {
 				$schema = [
@@ -651,7 +651,7 @@ foreach ($routes as $scope => $scopeRoutes) {
 			$pathParameters[] = $parameter;
 		}
 
-		$queryParameters = [];
+		$bodyParameters = [];
 		foreach ($route->controllerMethod->parameters as $parameter) {
 			$alreadyInPath = false;
 			foreach ($pathParameters as $pathParameter) {
@@ -661,7 +661,7 @@ foreach ($routes as $scope => $scopeRoutes) {
 				}
 			}
 			if (!$alreadyInPath) {
-				$queryParameters[] = $parameter;
+				$bodyParameters[] = $parameter;
 			}
 		}
 
@@ -689,19 +689,19 @@ foreach ($routes as $scope => $scopeRoutes) {
 				$contentTypeResponses = array_values(array_filter($statusCodeResponses, fn (ControllerMethodResponse $response) => $response->contentType == $contentType));
 
 				$hasEmpty = count(array_filter($contentTypeResponses, fn (ControllerMethodResponse $response) => $response->type == null)) > 0;
-				$uniqueResponses = array_values(array_intersect_key($contentTypeResponses, array_unique(array_map(fn (ControllerMethodResponse $response) => $response->type->toArray($openapiVersion), array_filter($contentTypeResponses, fn (ControllerMethodResponse $response) => $response->type != null)), SORT_REGULAR)));
+				$uniqueResponses = array_values(array_intersect_key($contentTypeResponses, array_unique(array_map(fn (ControllerMethodResponse $response) => $response->type->toArray(), array_filter($contentTypeResponses, fn (ControllerMethodResponse $response) => $response->type != null)), SORT_REGULAR)));
 				if (count($uniqueResponses) == 1) {
 					if ($hasEmpty) {
 						$mergedContentTypeResponses[$contentType] = [];
 					} else {
-						$schema = Helpers::cleanEmptyResponseArray($contentTypeResponses[0]->type->toArray($openapiVersion));
+						$schema = Helpers::cleanEmptyResponseArray($contentTypeResponses[0]->type->toArray());
 						$mergedContentTypeResponses[$contentType] = ["schema" => Helpers::wrapOCSResponse($route, $contentTypeResponses[0], $schema)];
 					}
 				} else {
 					$mergedContentTypeResponses[$contentType] = [
 						"schema" => [
-							[$hasEmpty ? "anyOf" : "oneOf" => array_map(function (ControllerMethodResponse $response) use ($route, $openapiVersion) {
-								$schema = Helpers::cleanEmptyResponseArray($response->type->toArray($openapiVersion));
+							[$hasEmpty ? "anyOf" : "oneOf" => array_map(function (ControllerMethodResponse $response) use ($route) {
+								$schema = Helpers::cleanEmptyResponseArray($response->type->toArray());
 								return Helpers::wrapOCSResponse($route, $response, $schema);
 							}, $uniqueResponses)],
 						],
@@ -717,7 +717,7 @@ foreach ($routes as $scope => $scopeRoutes) {
 					array_keys($headers),
 					array_map(
 						fn (OpenApiType $type) => [
-							"schema" => $type->toArray($openapiVersion),
+							"schema" => $type->toArray(),
 						],
 						array_values($headers),
 					),
@@ -761,25 +761,42 @@ foreach ($routes as $scope => $scopeRoutes) {
 		if (count($security) > 0) {
 			$operation["security"] = $security;
 		}
-		if (count($queryParameters) > 0 || count($pathParameters) > 0 || $route->isOCS) {
-			$parameters = [
-				...array_map(static function (ControllerMethodParameter $parameter) use ($openapiVersion) {
-					$out = [
-						"name" => $parameter->name . ($parameter->type->type === "array" ? "[]" : ""),
-						"in" => "query",
-					];
-					if ($parameter->docType !== null && $parameter->docType->description !== "") {
-						$out["description"] = Helpers::cleanDocComment($parameter->docType->description);
-					}
-					if (!$parameter->type->nullable && !$parameter->type->hasDefaultValue) {
-						$out["required"] = true;
-					}
-					$out["schema"] = $parameter->type->toArray($openapiVersion, true);
+		if (count($bodyParameters) > 0 || count($pathParameters) > 0 || $route->isOCS) {
+			$requiredBodyParameters = [];
+			$parameters = [];
 
-					return $out;
-				}, $queryParameters),
-				...$pathParameters,
-			];
+			foreach ($bodyParameters as $bodyParameter) {
+				$required = !$bodyParameter->type->nullable && !$bodyParameter->type->hasDefaultValue;
+				if ($required) {
+					$requiredBodyParameters[] = $bodyParameter->name;
+				}
+			}
+
+			if (count($bodyParameters) > 0) {
+				$required = count($requiredBodyParameters) > 0;
+
+				$schema = [
+					"type" => "object",
+				];
+				if ($required) {
+					$schema["required"] = $requiredBodyParameters;
+				}
+				$schema["properties"] = [];
+				foreach ($bodyParameters as $bodyParameter) {
+					$schema["properties"][$bodyParameter->name] = $bodyParameter->type->toArray();
+				}
+
+				$operation["requestBody"] = [
+					"required" => $required,
+					"content" => [
+						"application/json" => [
+							"schema" => $schema,
+						],
+					],
+				];
+			}
+
+			$parameters = array_merge($parameters, $pathParameters);
 			if ($route->isOCS) {
 				$parameters[] = [
 					"name" => "OCS-APIRequest",
@@ -792,7 +809,10 @@ foreach ($routes as $scope => $scopeRoutes) {
 					],
 				];
 			}
-			$operation["parameters"] = $parameters;
+
+			if (count($parameters) > 0) {
+				$operation["parameters"] = $parameters;
+			}
 		}
 		$operation["responses"] = $mergedResponses;
 

--- a/src/OpenApiType.php
+++ b/src/OpenApiType.php
@@ -53,44 +53,13 @@ class OpenApiType {
 	) {
 	}
 
-	public function toArray(string $openapiVersion, bool $isParameter = false): array|stdClass {
-		$asContentString = $isParameter && (
-			$this->type == "object" ||
-			$this->ref !== null ||
-			$this->anyOf !== null ||
-			$this->allOf !== null);
-		if ($asContentString) {
-			$values = [
-				"type" => "string",
-			];
-			if ($this->nullable) {
-				$values["nullable"] = true;
-			}
-			if (version_compare($openapiVersion, "3.1.0", ">=")) {
-				$values["contentMediaType"] = "application/json";
-				$values["contentSchema"] = $this->toArray($openapiVersion);
-			}
-
-			return $values;
-		}
-
-		$type = $this->type;
-		$defaultValue = $this->defaultValue;
-		$enum = $this->enum;
-		if ($isParameter && $type == "boolean") {
-			$type = "integer";
-			$enum = [0, 1];
-			if ($this->hasDefaultValue) {
-				$defaultValue = $defaultValue === true ? 1 : 0;
-			}
-		}
-
+	public function toArray(bool $isParameter = false): array|stdClass {
 		$values = [];
 		if ($this->ref !== null) {
 			$values["\$ref"] = $this->ref;
 		}
-		if ($type !== null) {
-			$values["type"] = $type;
+		if ($this->type !== null) {
+			$values["type"] = $this->type;
 		}
 		if ($this->format !== null) {
 			$values["format"] = $this->format;
@@ -98,17 +67,17 @@ class OpenApiType {
 		if ($this->nullable) {
 			$values["nullable"] = true;
 		}
-		if ($this->hasDefaultValue && $defaultValue !== null) {
-			$values["default"] = $defaultValue;
+		if ($this->hasDefaultValue && $this->defaultValue !== null) {
+			$values["default"] = $this->defaultValue;
 		}
-		if ($enum !== null) {
-			$values["enum"] = $enum;
+		if ($this->enum !== null) {
+			$values["enum"] = $this->enum;
 		}
 		if ($this->description !== null && $this->description !== "" && !$isParameter) {
 			$values["description"] = $this->description;
 		}
 		if ($this->items !== null) {
-			$values["items"] = $this->items->toArray($openapiVersion);
+			$values["items"] = $this->items->toArray();
 		}
 		if ($this->minLength !== null) {
 			$values["minLength"] = $this->minLength;
@@ -133,24 +102,24 @@ class OpenApiType {
 		}
 		if ($this->properties !== null && count($this->properties) > 0) {
 			$values["properties"] = array_combine(array_keys($this->properties),
-				array_map(static fn (OpenApiType $property) => $property->toArray($openapiVersion), array_values($this->properties)),
+				array_map(static fn (OpenApiType $property) => $property->toArray(), array_values($this->properties)),
 			);
 		}
 		if ($this->additionalProperties !== null) {
 			if ($this->additionalProperties instanceof OpenApiType) {
-				$values["additionalProperties"] = $this->additionalProperties->toArray($openapiVersion);
+				$values["additionalProperties"] = $this->additionalProperties->toArray();
 			} else {
 				$values["additionalProperties"] = $this->additionalProperties;
 			}
 		}
 		if ($this->oneOf !== null) {
-			$values["oneOf"] = array_map(fn (OpenApiType $type) => $type->toArray($openapiVersion), $this->oneOf);
+			$values["oneOf"] = array_map(fn (OpenApiType $type) => $type->toArray(), $this->oneOf);
 		}
 		if ($this->anyOf !== null) {
-			$values["anyOf"] = array_map(fn (OpenApiType $type) => $type->toArray($openapiVersion), $this->anyOf);
+			$values["anyOf"] = array_map(fn (OpenApiType $type) => $type->toArray(), $this->anyOf);
 		}
 		if ($this->allOf !== null) {
-			$values["allOf"] = array_map(fn (OpenApiType $type) => $type->toArray($openapiVersion), $this->allOf);
+			$values["allOf"] = array_map(fn (OpenApiType $type) => $type->toArray(), $this->allOf);
 		}
 
 		return count($values) > 0 ? $values : new stdClass();

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -458,29 +458,39 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum number of objects",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                1,
-                                2,
-                                3,
-                                4,
-                                5,
-                                6,
-                                7,
-                                8,
-                                9,
-                                10
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10
+                                        ],
+                                        "description": "Maximum number of objects"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -552,19 +562,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Between 5 and 10",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 5,
-                            "maximum": 10
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Between 5 and 10",
+                                        "minimum": 5,
+                                        "maximum": 10
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -636,18 +656,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "At least 5",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 5
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "At least 5",
+                                        "minimum": 5
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -719,18 +749,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "At most 10",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "maximum": 10
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "At most 10",
+                                        "maximum": 10
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -802,18 +842,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "not negative",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "not negative",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -885,18 +935,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "positive",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 1
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "positive",
+                                        "minimum": 1
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -968,18 +1028,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "negative",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "maximum": -1
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "negative",
+                                        "maximum": -1
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1051,18 +1121,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "non positive",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "maximum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "non positive",
+                                        "maximum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1134,37 +1214,47 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "weird",
-                        "in": "query",
-                        "description": "Weird list",
-                        "required": true,
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "integer",
-                                    "enum": [
-                                        0,
-                                        1
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "yes",
-                                        "no"
-                                    ]
-                                },
-                                {
-                                    "type": "boolean",
-                                    "enum": [
-                                        true
-                                    ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "weird"
+                                ],
+                                "properties": {
+                                    "weird": {
+                                        "description": "Weird list",
+                                        "oneOf": [
+                                            {
+                                                "type": "integer",
+                                                "enum": [
+                                                    0,
+                                                    1
+                                                ]
+                                            },
+                                            {
+                                                "type": "string",
+                                                "enum": [
+                                                    "yes",
+                                                    "no"
+                                                ]
+                                            },
+                                            {
+                                                "type": "boolean",
+                                                "enum": [
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1236,38 +1326,48 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "weird",
-                        "in": "query",
-                        "description": "Weird list",
-                        "required": true,
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "integer",
-                                    "enum": [
-                                        0,
-                                        1
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "yes",
-                                        "no"
-                                    ]
-                                },
-                                {
-                                    "type": "boolean",
-                                    "enum": [
-                                        true,
-                                        false
-                                    ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "weird"
+                                ],
+                                "properties": {
+                                    "weird": {
+                                        "description": "Weird list",
+                                        "oneOf": [
+                                            {
+                                                "type": "integer",
+                                                "enum": [
+                                                    0,
+                                                    1
+                                                ]
+                                            },
+                                            {
+                                                "type": "string",
+                                                "enum": [
+                                                    "yes",
+                                                    "no"
+                                                ]
+                                            },
+                                            {
+                                                "type": "boolean",
+                                                "enum": [
+                                                    true,
+                                                    false
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1339,20 +1439,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "Boolean required",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "Boolean required"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1424,20 +1530,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "Boolean defaulting to false",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Boolean defaulting to false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1509,20 +1619,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "Boolean defaulting to true",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Boolean defaulting to true"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1594,20 +1708,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "boolean or true",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "boolean or true"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1679,20 +1799,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "boolean or false",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "boolean or false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1764,20 +1890,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "boolean or true or false",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "boolean or true or false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1849,20 +1981,30 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "true or false",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "enum": [
+                                            true,
+                                            false
+                                        ],
+                                        "description": "true or false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1934,16 +2076,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "string or 'test'",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "value"
+                                ],
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "description": "string or 'test'"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2015,17 +2167,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "int or 0",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "value"
+                                ],
+                                "properties": {
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "int or 0"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2097,16 +2259,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "Some numeric value",
-                        "required": true,
-                        "schema": {
-                            "type": "number"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "value"
+                                ],
+                                "properties": {
+                                    "value": {
+                                        "type": "number",
+                                        "description": "Some numeric value"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2178,21 +2350,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value[]",
-                        "in": "query",
-                        "description": "Some array value",
-                        "schema": {
-                            "type": "array",
-                            "default": [
-                                "test"
-                            ],
-                            "items": {
-                                "type": "string"
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "type": "array",
+                                        "default": [
+                                            "test"
+                                        ],
+                                        "description": "Some array value",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2264,15 +2444,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "Some array value",
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "type": "object",
+                                        "default": {
+                                            "test": "abc"
+                                        },
+                                        "description": "Some array value",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -585,29 +585,39 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum number of objects",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                1,
-                                2,
-                                3,
-                                4,
-                                5,
-                                6,
-                                7,
-                                8,
-                                9,
-                                10
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10
+                                        ],
+                                        "description": "Maximum number of objects"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -679,19 +689,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Between 5 and 10",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 5,
-                            "maximum": 10
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Between 5 and 10",
+                                        "minimum": 5,
+                                        "maximum": 10
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -763,18 +783,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "At least 5",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 5
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "At least 5",
+                                        "minimum": 5
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -846,18 +876,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "At most 10",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "maximum": 10
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "At most 10",
+                                        "maximum": 10
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -929,18 +969,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "not negative",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "not negative",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1012,18 +1062,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "positive",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 1
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "positive",
+                                        "minimum": 1
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1095,18 +1155,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "negative",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "maximum": -1
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "negative",
+                                        "maximum": -1
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1178,18 +1248,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "non positive",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "maximum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "non positive",
+                                        "maximum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1261,37 +1341,47 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "weird",
-                        "in": "query",
-                        "description": "Weird list",
-                        "required": true,
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "integer",
-                                    "enum": [
-                                        0,
-                                        1
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "yes",
-                                        "no"
-                                    ]
-                                },
-                                {
-                                    "type": "boolean",
-                                    "enum": [
-                                        true
-                                    ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "weird"
+                                ],
+                                "properties": {
+                                    "weird": {
+                                        "description": "Weird list",
+                                        "oneOf": [
+                                            {
+                                                "type": "integer",
+                                                "enum": [
+                                                    0,
+                                                    1
+                                                ]
+                                            },
+                                            {
+                                                "type": "string",
+                                                "enum": [
+                                                    "yes",
+                                                    "no"
+                                                ]
+                                            },
+                                            {
+                                                "type": "boolean",
+                                                "enum": [
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1363,38 +1453,48 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "weird",
-                        "in": "query",
-                        "description": "Weird list",
-                        "required": true,
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "integer",
-                                    "enum": [
-                                        0,
-                                        1
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "yes",
-                                        "no"
-                                    ]
-                                },
-                                {
-                                    "type": "boolean",
-                                    "enum": [
-                                        true,
-                                        false
-                                    ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "weird"
+                                ],
+                                "properties": {
+                                    "weird": {
+                                        "description": "Weird list",
+                                        "oneOf": [
+                                            {
+                                                "type": "integer",
+                                                "enum": [
+                                                    0,
+                                                    1
+                                                ]
+                                            },
+                                            {
+                                                "type": "string",
+                                                "enum": [
+                                                    "yes",
+                                                    "no"
+                                                ]
+                                            },
+                                            {
+                                                "type": "boolean",
+                                                "enum": [
+                                                    true,
+                                                    false
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1466,20 +1566,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "Boolean required",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "Boolean required"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1551,20 +1657,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "Boolean defaulting to false",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Boolean defaulting to false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1636,20 +1746,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "Boolean defaulting to true",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Boolean defaulting to true"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1721,20 +1835,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "boolean or true",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "boolean or true"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1806,20 +1926,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "boolean or false",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "boolean or false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1891,20 +2017,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "boolean or true or false",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "description": "boolean or true or false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1976,20 +2108,30 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "yesOrNo",
-                        "in": "query",
-                        "description": "true or false",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "yesOrNo"
+                                ],
+                                "properties": {
+                                    "yesOrNo": {
+                                        "type": "boolean",
+                                        "enum": [
+                                            true,
+                                            false
+                                        ],
+                                        "description": "true or false"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2061,16 +2203,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "string or 'test'",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "value"
+                                ],
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "description": "string or 'test'"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2142,17 +2294,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "int or 0",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "value"
+                                ],
+                                "properties": {
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "int or 0"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2224,16 +2386,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "Some numeric value",
-                        "required": true,
-                        "schema": {
-                            "type": "number"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "value"
+                                ],
+                                "properties": {
+                                    "value": {
+                                        "type": "number",
+                                        "description": "Some numeric value"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2305,21 +2477,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value[]",
-                        "in": "query",
-                        "description": "Some array value",
-                        "schema": {
-                            "type": "array",
-                            "default": [
-                                "test"
-                            ],
-                            "items": {
-                                "type": "string"
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "type": "array",
+                                        "default": [
+                                            "test"
+                                        ],
+                                        "description": "Some array value",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2391,15 +2571,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "Some array value",
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "type": "object",
+                                        "default": {
+                                            "test": "abc"
+                                        },
+                                        "description": "Some array value",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",


### PR DESCRIPTION
Closes https://github.com/nextcloud/openapi-extractor/issues/88

This fixes a lot of cases where the query parameters was just typed as string because it was not possible to correctly set the type.