### PR TITLE
fix: Keep old path parameter property order

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -620,12 +620,12 @@ foreach ($routes as $scope => $scopeRoutes) {
 			$parameter = [
 				"name" => $urlParameter,
 				"in" => "path",
-				"required" => true,
-				"schema" => $schema,
 			];
 			if ($description !== null) {
 				$parameter["description"] = $description;
 			}
+			$parameter["required"] = true;
+			$parameter["schema"] = $schema;
 
 			$pathParameters[] = $parameter;
 		}


### PR DESCRIPTION
https://github.com/nextcloud/openapi-extractor/pull/104 accidentally changed the order of the properties for path parameters. To avoid unnecessary diffs that would appear when using the new version I'm reverting it to the old order (which is also a bit more readable).