### PR TITLE
fix: Ensure operationIds are unique

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -329,6 +329,8 @@ if (count($parsedRoutes) === 0) {
 	Logger::warning("Routes", "No routes were loaded");
 }
 
+$operationIds = [];
+
 foreach ($parsedRoutes as $key => $value) {
 	$isOCS = $key === "ocs";
 	$isIndex = $key === "routes";
@@ -531,6 +533,11 @@ foreach ($parsedRoutes as $key => $value) {
 			$operationId[] = $postfix;
 		}
 		$operationId = strtolower(implode("-", $operationId));
+
+		if (in_array($operationId, $operationIds, true)) {
+			Logger::panic($routeName, 'Route is not unique! If you want to have two routes pointing to the same controller method you must specify a postfix on at least one of the routes.');
+		}
+		$operationIds[] = $operationId;
 
 		foreach ($scopes as $scope) {
 			$routes[$scope] ??= [];

--- a/generate-spec
+++ b/generate-spec
@@ -523,13 +523,21 @@ foreach ($parsedRoutes as $key => $value) {
 			continue;
 		}
 
+		$operationId = [
+			$tagName,
+			...Helpers::splitOnUppercaseFollowedByNonUppercase($methodName)
+		];
+		if ($postfix !== null) {
+			$operationId[] = $postfix;
+		}
+		$operationId = strtolower(implode("-", $operationId));
+
 		foreach ($scopes as $scope) {
 			$routes[$scope] ??= [];
 			$routes[$scope][] = new Route(
 				$routeName,
 				$routeTags[$scope] ?? [$tagName],
-				$methodName,
-				$postfix,
+				$operationId,
 				$verb,
 				$url,
 				$requirements,
@@ -714,11 +722,6 @@ foreach ($routes as $scope => $scopeRoutes) {
 			$mergedResponses[$statusCode] = $response;
 		}
 
-		$operationId = [...$route->tags, ...Helpers::splitOnUppercaseFollowedByNonUppercase($route->methodName)];
-		if ($route->postfix != null) {
-			$operationId[] = $route->postfix;
-		}
-
 		$security = [];
 		if ($route->isPublic) {
 			// Add empty authentication, meaning that it's optional. We can't know if there is a difference in behaviour for authenticated vs. unauthenticated access on public pages (e.g. capabilities)
@@ -734,7 +737,7 @@ foreach ($routes as $scope => $scopeRoutes) {
 		}
 
 		$operation = [
-			"operationId" => strtolower(implode("-", $operationId)),
+			"operationId" => $route->operationId,
 		];
 		if ($route->controllerMethod->summary !== null) {
 			$operation["summary"] = $route->controllerMethod->summary;

--- a/src/Route.php
+++ b/src/Route.php
@@ -6,8 +6,7 @@ class Route {
 	public function __construct(
 		public string $name,
 		public array $tags,
-		public string $methodName,
-		public ?string $postfix,
+		public string $operationId,
 		public string $verb,
 		public string $url,
 		public array $requirements,

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -154,7 +154,7 @@
         },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/moved-with-tag": {
             "post": {
-                "operationId": "settings-admin-settings-moved-to-settings-tag",
+                "operationId": "admin_settings-moved-to-settings-tag",
                 "summary": "Route in default scope with tags",
                 "description": "This endpoint requires admin access",
                 "tags": [
@@ -227,7 +227,7 @@
         },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/moved-with-unnamed-tag": {
             "post": {
-                "operationId": "settings-admin-settings-moved-to-settings-tag-unnamed",
+                "operationId": "admin_settings-moved-to-settings-tag-unnamed",
                 "summary": "Route in default scope with tags but without named parameters on the attribute",
                 "description": "This endpoint requires admin access",
                 "tags": [

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -281,7 +281,7 @@
         },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/moved-with-tag": {
             "post": {
-                "operationId": "settings-admin-settings-moved-to-settings-tag",
+                "operationId": "admin_settings-moved-to-settings-tag",
                 "summary": "Route in default scope with tags",
                 "description": "This endpoint requires admin access",
                 "tags": [
@@ -354,7 +354,7 @@
         },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/moved-with-unnamed-tag": {
             "post": {
-                "operationId": "settings-admin-settings-moved-to-settings-tag-unnamed",
+                "operationId": "admin_settings-moved-to-settings-tag-unnamed",
                 "summary": "Route in default scope with tags but without named parameters on the attribute",
                 "description": "This endpoint requires admin access",
                 "tags": [


### PR DESCRIPTION
Fixes https://github.com/nextcloud/openapi-extractor/issues/98

Tags are not longer used for the operationId because it is possible to tag two controller methods with the same names in two different controllers with the same tag and the output would be the same operationId. Talk is currently affected by this problem.
The failure results in a panic and can not be skipped because the result would be an invalid spec.
The CI for Talk will fail because it currently has a controller method with two routes that are not unique.