### PR TITLE
perf: Limit files searched for capabilities

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -168,10 +168,9 @@ foreach ($capabilitiesDirs as $dir) {
 	$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
 	foreach ($iterator as $file) {
 		$path = $file->getPathname();
-		if (!str_ends_with($path, ".php")) {
-			continue;
+		if (str_ends_with($path, "Capabilities.php")) {
+			$capabilitiesFiles[] = $path;
 		}
-		$capabilitiesFiles[] = $path;
 	}
 }
 sort($capabilitiesFiles);


### PR DESCRIPTION
Closes https://github.com/nextcloud/openapi-extractor/issues/3

Quite a big performance improvement:
server: 11s -> 3s
spreed: 4s -> 2s