### PR TITLE
fix(merge-specs): Avoid duplicate capabilities entries

### DIFF
--- a/merge-specs
+++ b/merge-specs
@@ -66,6 +66,9 @@ $data = [
 ];
 
 foreach ($otherSpecPaths as $specPath) {
+	if ($specPath === $coreSpecPath) {
+		continue;
+	}
 	$spec = loadSpec($specPath);
 	$data["components"]["schemas"] = array_merge($data["components"]["schemas"], rewriteSchemaNames($spec));
 	$data["tags"] = array_merge($data["tags"], rewriteTags($spec));


### PR DESCRIPTION
When using a glob to include the other specs and the core spec is also among them the capabilities would get included twice.
https://github.com/nextcloud/neon/issues/2004