### PR TITLE
fix: use schemas only from request body

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -948,6 +948,15 @@ foreach ($scopePaths as $scope => $paths) {
 						}
 					}
 				}
+				if (empty($routeData['requestBody']['content'])) {
+					continue;
+				}
+				foreach ($routeData['requestBody']['content'] as $contentType => $contentData) {
+					if (isset($contentData['schema']) && is_array($contentData['schema'])) {
+						$newSchemas = Helpers::collectUsedRefs($contentData['schema']);
+						$usedSchemas = array_merge($usedSchemas, $newSchemas);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
## Scope

Have schemas that only exists at requestBody and at this case, if we don't fetch from body will throw an error "Can't resolve $ref" when run openapi-typescript build.

## How to reproduce

- Create a new endpoint with an object as param
	```php
	/**
	 * Route with param
	 *
	 * @param FakeParam $fake Fake param
	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
	 *
	 * 200: Personal settings updated
	 */
	#[OpenAPI]
	public function fakeMethod DataResponse {
		return new DataResponse();
	}
	```
- Add the FakeParam to ResponseDefinitions
	```
	 * @psalm-type NotificationsRequestProperty = array{
	 *     publicKey: string,
	 *     signature: string,
	 * }
	````
- Build with the follow command:
	```
	npx openapi-typescript -t
	```

## Expected behavior

```
> dummyapp@0.0.1 typescript:generate
> npx openapi-typescript -t

🚀 openapi@v1 → ./src/types/openapi/openapi.ts [141.7ms]

```

## Actual behavior
```
> dummyapp@0.0.1 typescript:generate
> npx openapi-typescript -t

 ✘  Can't resolve $ref
file:///var/www/html/apps-extra/dummyapp/node_modules/openapi-typescript/dist/lib/redoc.js:121
                throw new Error(problem.message);
                      ^

Error: Can't resolve $ref
    at validateAndBundle (file:///var/www/html/apps-extra/dummyapp/node_modules/openapi-typescript/dist/lib/redoc.js:121:23)
    at async openapiTS (file:///var/www/html/apps-extra/dummyapp/node_modules/openapi-typescript/dist/index.js:40:20)
    at async generateSchema (file:///var/www/html/apps-extra/dummyapp/node_modules/openapi-typescript/bin/cli.js:119:5)
    at async file:///var/www/html/apps-extra/dummyapp/node_modules/openapi-typescript/bin/cli.js:195:24
    at async Promise.all (index 0)
    at async main (file:///var/www/html/apps-extra/dummyapp/node_modules/openapi-typescript/bin/cli.js:181:5)

Node.js v20.15.1
Please manually regenerate the typescript OpenAPI models

```

## Artifacts

### Without fix

![Screenshot_20240802_161158](https://github.com/user-attachments/assets/b51a2768-d8db-41f1-9aa1-2b7f96827b2c)

![Screenshot_20240802_161041](https://github.com/user-attachments/assets/b8646ea3-3a95-479c-8ae1-ac8b5ddfaee5)

---

### With fix

![Screenshot_20240802_161424](https://github.com/user-attachments/assets/c7bc4816-7419-43ad-bbe0-9315f5cfda46)

![Screenshot_20240802_161346](https://github.com/user-attachments/assets/8359c714-45a6-48fd-b68a-7c5520de7e2e)


## Tests

Considering that the test only build the json files and not the ts files, I didn't implemented tests.