### PR TITLE
Fix request body usage for GET/HEAD/DELETE requests

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -654,6 +654,7 @@ foreach ($routes as $scope => $scopeRoutes) {
 			$pathParameters[] = $parameter;
 		}
 
+		$queryParameters = [];
 		$bodyParameters = [];
 		foreach ($route->controllerMethod->parameters as $parameter) {
 			$alreadyInPath = false;
@@ -664,7 +665,11 @@ foreach ($routes as $scope => $scopeRoutes) {
 				}
 			}
 			if (!$alreadyInPath) {
-				$bodyParameters[] = $parameter;
+				if (in_array(strtolower($route->verb), ['put', 'post', 'patch'])) {
+					$bodyParameters[] = $parameter;
+				} else {
+					$queryParameters[] = $parameter;
+				}
 			}
 		}
 
@@ -799,6 +804,21 @@ foreach ($routes as $scope => $scopeRoutes) {
 		}
 
 		$parameters = $pathParameters;
+		foreach ($queryParameters as $queryParameter) {
+			$parameter = [
+				"name" => $queryParameter->name . ($queryParameter->type->type === "array" ? "[]" : ""),
+				"in" => "query",
+			];
+			if ($queryParameter->docType !== null && $queryParameter->docType->description !== "") {
+				$parameter["description"] = Helpers::cleanDocComment($queryParameter->docType->description);
+			}
+			if (!$queryParameter->type->nullable && !$queryParameter->type->hasDefaultValue) {
+				$parameter["required"] = true;
+			}
+			$parameter["schema"] = $queryParameter->type->toArray(true);
+
+			$parameters[] = $parameter;
+		}
 		if ($route->isOCS) {
 			$parameters[] = [
 				"name" => "OCS-APIRequest",

--- a/generate-spec
+++ b/generate-spec
@@ -764,9 +764,9 @@ foreach ($routes as $scope => $scopeRoutes) {
 		if (count($security) > 0) {
 			$operation["security"] = $security;
 		}
-		if (count($bodyParameters) > 0 || count($pathParameters) > 0 || $route->isOCS) {
+
+		if (count($bodyParameters) > 0) {
 			$requiredBodyParameters = [];
-			$parameters = [];
 
 			foreach ($bodyParameters as $bodyParameter) {
 				$required = !$bodyParameter->type->nullable && !$bodyParameter->type->hasDefaultValue;
@@ -775,48 +775,46 @@ foreach ($routes as $scope => $scopeRoutes) {
 				}
 			}
 
-			if (count($bodyParameters) > 0) {
-				$required = count($requiredBodyParameters) > 0;
+			$required = count($requiredBodyParameters) > 0;
 
-				$schema = [
-					"type" => "object",
-				];
-				if ($required) {
-					$schema["required"] = $requiredBodyParameters;
-				}
-				$schema["properties"] = [];
-				foreach ($bodyParameters as $bodyParameter) {
-					$schema["properties"][$bodyParameter->name] = $bodyParameter->type->toArray();
-				}
+			$schema = [
+				"type" => "object",
+			];
+			if ($required) {
+				$schema["required"] = $requiredBodyParameters;
+			}
+			$schema["properties"] = [];
+			foreach ($bodyParameters as $bodyParameter) {
+				$schema["properties"][$bodyParameter->name] = $bodyParameter->type->toArray();
+			}
 
-				$operation["requestBody"] = [
-					"required" => $required,
-					"content" => [
-						"application/json" => [
-							"schema" => $schema,
-						],
+			$operation["requestBody"] = [
+				"required" => $required,
+				"content" => [
+					"application/json" => [
+						"schema" => $schema,
 					],
-				];
-			}
-
-			$parameters = array_merge($parameters, $pathParameters);
-			if ($route->isOCS) {
-				$parameters[] = [
-					"name" => "OCS-APIRequest",
-					"in" => "header",
-					"description" => "Required to be true for the API request to pass",
-					"required" => true,
-					"schema" => [
-						"type" => "boolean",
-						"default" => true,
-					],
-				];
-			}
-
-			if (count($parameters) > 0) {
-				$operation["parameters"] = $parameters;
-			}
+				],
+			];
 		}
+
+		$parameters = $pathParameters;
+		if ($route->isOCS) {
+			$parameters[] = [
+				"name" => "OCS-APIRequest",
+				"in" => "header",
+				"description" => "Required to be true for the API request to pass",
+				"required" => true,
+				"schema" => [
+					"type" => "boolean",
+					"default" => true,
+				],
+			];
+		}
+		if (count($parameters) > 0) {
+			$operation["parameters"] = $parameters;
+		}
+
 		$operation["responses"] = $mergedResponses;
 
 		$scopePaths[$scope] ??= [];
@@ -981,7 +979,7 @@ foreach ($scopePaths as $scope => $paths) {
 		}
 
 		if (count($scopedSchemas) === 0) {
-			$scopedSchemas = new \stdClass();
+			$scopedSchemas = new stdClass();
 		} else {
 			ksort($scopedSchemas);
 		}
@@ -992,7 +990,7 @@ foreach ($scopePaths as $scope => $paths) {
 	$pathsCount = count($openapiScope['paths']);
 	if ($pathsCount === 0) {
 		// Make sure the paths array is always a dictionary
-		$openapiScope['paths'] = new \stdClass();
+		$openapiScope['paths'] = new stdClass();
 	}
 
 	$startExtension = strrpos($out, '.');

--- a/src/ControllerMethod.php
+++ b/src/ControllerMethod.php
@@ -84,9 +84,9 @@ class ControllerMethod {
 							}
 
 							if (str_starts_with($type->name, 'OCS') && str_ends_with($type->name, 'Exception')) {
-								$responses[] = new ControllerMethodResponse($docNode->value->type, $statusCode, "application/json", new OpenApiType(type: "array", maxItems: 0), null);
+								$responses[] = new ControllerMethodResponse($docNode->value->type, $statusCode, "application/json", new OpenApiType(context: $context, type: "array", maxItems: 0), null);
 							} else {
-								$responses[] = new ControllerMethodResponse($docNode->value->type, $statusCode, "text/plain", new OpenApiType(type: "string"), null);
+								$responses[] = new ControllerMethodResponse($docNode->value->type, $statusCode, "text/plain", new OpenApiType(context: $context, type: "string"), null);
 							}
 						}
 					}

--- a/src/OpenApiType.php
+++ b/src/OpenApiType.php
@@ -54,6 +54,27 @@ class OpenApiType {
 	}
 
 	public function toArray(bool $isParameter = false): array|stdClass {
+		if ($isParameter) {
+			if ($this->type === 'boolean') {
+				return (new OpenApiType(
+					type: 'integer',
+					nullable: $this->nullable,
+					hasDefaultValue: $this->hasDefaultValue,
+					defaultValue: !$this->hasDefaultValue ? null : ($this->defaultValue === true ? 1 : 0),
+					description: $this->description,
+					enum: [0, 1],
+				))->toArray($isParameter);
+			}
+
+			if ($this->type === 'object' || $this->ref !== null || $this->anyOf !== null || $this->allOf !== null) {
+				return (new OpenApiType(
+					type: 'string',
+					nullable: $this->nullable,
+					description: $this->description,
+				))->toArray($isParameter);
+			}
+		}
+
 		$values = [];
 		if ($this->ref !== null) {
 			$values["\$ref"] = $this->ref;

--- a/src/ResponseType.php
+++ b/src/ResponseType.php
@@ -22,8 +22,9 @@ class ResponseType {
 
 	/** @return ResponseType[] */
 	public static function getAll(): array {
-		$stringType = new OpenApiType(type: "string");
-		$binaryType = new OpenApiType(type: "string", format: "binary");
+		$context = 'Response Types';
+		$stringType = new OpenApiType(context: $context, type: "string");
+		$binaryType = new OpenApiType(context: $context, type: "string", format: "binary");
 		return [
 			new ResponseType(
 				"DataDisplayResponse",

--- a/tests/appinfo/routes.php
+++ b/tests/appinfo/routes.php
@@ -76,5 +76,11 @@ return [
 		['name' => 'Settings#anyOf', 'url' => '/api/{apiVersion}/anyOf', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#floatDouble', 'url' => '/api/{apiVersion}/floatDouble', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#emptyArray', 'url' => '/api/{apiVersion}/emptyArray', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterGET', 'verb' => 'GET', 'postfix' => 'GET', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterHEAD', 'verb' => 'HEAD', 'postfix' => 'HEAD', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterPOST', 'verb' => 'POST', 'postfix' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterPUT', 'verb' => 'PUT', 'postfix' => 'PUT', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterDELETE', 'verb' => 'DELETE', 'postfix' => 'DELETE', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterPATCH', 'verb' => 'PATCH', 'postfix' => 'PATCH', 'requirements' => ['apiVersion' => '(v2)']],
 	],
 ];

--- a/tests/lib/Controller/SettingsController.php
+++ b/tests/lib/Controller/SettingsController.php
@@ -538,4 +538,18 @@ class SettingsController extends OCSController {
 	public function emptyArray(): DataResponse {
 		return new DataResponse();
 	}
+
+	/**
+	 * Route with parameter
+	 *
+	 * @param int $simple Value
+	 * @param array<string, string> $complex Values
+	 * @return DataResponse<Http::STATUS_OK, array{test: array<empty>}, array{}>
+	 *
+	 * 200: OK
+	 */
+	#[PasswordConfirmationRequired]
+	public function parameterRequestBody(int $simple, array $complex): DataResponse {
+		return new DataResponse();
+	}
 }

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -3298,6 +3298,645 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterGET": {
+            "get": {
+                "operationId": "settings-parameter-request-body-get",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "simple",
+                        "in": "query",
+                        "description": "Value",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "complex",
+                        "in": "query",
+                        "description": "Values",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterHEAD": {
+            "head": {
+                "operationId": "settings-parameter-request-body-head",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "simple",
+                        "in": "query",
+                        "description": "Value",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "complex",
+                        "in": "query",
+                        "description": "Values",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterPOST": {
+            "post": {
+                "operationId": "settings-parameter-request-body-post",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "simple",
+                                    "complex"
+                                ],
+                                "properties": {
+                                    "simple": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Value"
+                                    },
+                                    "complex": {
+                                        "type": "object",
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterPUT": {
+            "put": {
+                "operationId": "settings-parameter-request-body-put",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "simple",
+                                    "complex"
+                                ],
+                                "properties": {
+                                    "simple": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Value"
+                                    },
+                                    "complex": {
+                                        "type": "object",
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterDELETE": {
+            "delete": {
+                "operationId": "settings-parameter-request-body-delete",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "simple",
+                        "in": "query",
+                        "description": "Value",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "complex",
+                        "in": "query",
+                        "description": "Values",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterPATCH": {
+            "patch": {
+                "operationId": "settings-parameter-request-body-patch",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "simple",
+                                    "complex"
+                                ],
+                                "properties": {
+                                    "simple": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Value"
+                                    },
+                                    "complex": {
+                                        "type": "object",
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/tests/attribute-ocs/{param}": {
             "get": {
                 "operationId": "routing-attributeocs-route",

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -3425,6 +3425,645 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterGET": {
+            "get": {
+                "operationId": "settings-parameter-request-body-get",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "simple",
+                        "in": "query",
+                        "description": "Value",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "complex",
+                        "in": "query",
+                        "description": "Values",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterHEAD": {
+            "head": {
+                "operationId": "settings-parameter-request-body-head",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "simple",
+                        "in": "query",
+                        "description": "Value",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "complex",
+                        "in": "query",
+                        "description": "Values",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterPOST": {
+            "post": {
+                "operationId": "settings-parameter-request-body-post",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "simple",
+                                    "complex"
+                                ],
+                                "properties": {
+                                    "simple": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Value"
+                                    },
+                                    "complex": {
+                                        "type": "object",
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterPUT": {
+            "put": {
+                "operationId": "settings-parameter-request-body-put",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "simple",
+                                    "complex"
+                                ],
+                                "properties": {
+                                    "simple": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Value"
+                                    },
+                                    "complex": {
+                                        "type": "object",
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterDELETE": {
+            "delete": {
+                "operationId": "settings-parameter-request-body-delete",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "simple",
+                        "in": "query",
+                        "description": "Value",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "complex",
+                        "in": "query",
+                        "description": "Values",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/parameterPATCH": {
+            "patch": {
+                "operationId": "settings-parameter-request-body-patch",
+                "summary": "Route with parameter",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "simple",
+                                    "complex"
+                                ],
+                                "properties": {
+                                    "simple": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Value"
+                                    },
+                                    "complex": {
+                                        "type": "object",
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/tests/attribute-ocs/{param}": {
             "get": {
                 "operationId": "routing-attributeocs-route",


### PR DESCRIPTION
Fixes https://github.com/nextcloud/openapi-extractor/issues/144

The undefined serialization behavior warning can probably be fixed by implementing the deepObject serialization style (as described in https://swagger.io/docs/specification/serialization), but it needs a lot more investigation and refactoring that is out of scope for this partial revert to fix the current mess.