### PR TITLE
fix(OpenApiType): Use correct default values for empty object types

### DIFF
--- a/src/OpenApiType.php
+++ b/src/OpenApiType.php
@@ -94,7 +94,11 @@ class OpenApiType {
 			$values["nullable"] = true;
 		}
 		if ($this->hasDefaultValue && $this->defaultValue !== null) {
-			$values["default"] = $this->defaultValue;
+			if ($this->type === 'object' && empty($this->defaultValue)) {
+				$values["default"] = new stdClass();
+			} else {
+				$values["default"] = $this->defaultValue;
+			}
 		}
 		if ($this->enum !== null) {
 			$values["enum"] = $this->enum;

--- a/tests/appinfo/routes.php
+++ b/tests/appinfo/routes.php
@@ -82,5 +82,6 @@ return [
 		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterPUT', 'verb' => 'PUT', 'postfix' => 'PUT', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterDELETE', 'verb' => 'DELETE', 'postfix' => 'DELETE', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#parameterRequestBody', 'url' => '/api/{apiVersion}/parameterPATCH', 'verb' => 'PATCH', 'postfix' => 'PATCH', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#objectDefaults', 'url' => '/api/{apiVersion}/objectDefaults', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 	],
 ];

--- a/tests/lib/Controller/SettingsController.php
+++ b/tests/lib/Controller/SettingsController.php
@@ -552,4 +552,19 @@ class SettingsController extends OCSController {
 	public function parameterRequestBody(int $simple, array $complex): DataResponse {
 		return new DataResponse();
 	}
+
+
+	/**
+	 * Route with object defaults
+	 *
+	 * @param array<string, string> $empty Empty
+	 * @param array<string, string> $values Values
+	 * @return DataResponse<Http::STATUS_OK, array{test: array<empty>}, array{}>
+	 *
+	 * 200: OK
+	 */
+	#[PasswordConfirmationRequired]
+	public function objectDefaults(array $empty = [], array $values = ['key' => 'value']): DataResponse {
+		return new DataResponse();
+	}
 }

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -3937,6 +3937,119 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/objectDefaults": {
+            "post": {
+                "operationId": "settings-object-defaults",
+                "summary": "Route with object defaults",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "empty": {
+                                        "type": "object",
+                                        "default": {},
+                                        "description": "Empty",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "values": {
+                                        "type": "object",
+                                        "default": {
+                                            "key": "value"
+                                        },
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/tests/attribute-ocs/{param}": {
             "get": {
                 "operationId": "routing-attributeocs-route",

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -4079,6 +4079,119 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/objectDefaults": {
+            "post": {
+                "operationId": "settings-object-defaults",
+                "summary": "Route with object defaults",
+                "description": "This endpoint requires admin access\nThis endpoint requires password confirmation",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "empty": {
+                                        "type": "object",
+                                        "default": {},
+                                        "description": "Empty",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "values": {
+                                        "type": "object",
+                                        "default": {
+                                            "key": "value"
+                                        },
+                                        "description": "Values",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "test"
+                                                    ],
+                                                    "properties": {
+                                                        "test": {
+                                                            "type": "array",
+                                                            "maxItems": 0
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/tests/attribute-ocs/{param}": {
             "get": {
                 "operationId": "routing-attributeocs-route",


### PR DESCRIPTION
Fixes https://github.com/nextcloud/openapi-extractor/issues/147

Classic case of PHP array handling again... If the array value is empty it is always converted to `[]` in JSON while it should be `{}` in case the type is something like `array<string, string>`.