### PR TITLE
fix: Remove dangerous --continue-on-error flag

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -41,7 +41,6 @@ $command
 	->option('--first-content-type', 'Only output the first content type')
 	->option('--allow-missing-docs', 'Allow missing documentation fields')
 	->option('--no-tags', 'Use no tags')
-	->option('--continue-on-error', 'Continue on error')
 	->option('--openapi-version', 'OpenAPI version to use', null, '3.0.3')
 	->option('--verbose', 'Verbose logging')
 	->parse($_SERVER["argv"]);
@@ -52,7 +51,6 @@ $firstStatusCode = $command->firstStatusCode ?? false;
 $firstContentType = $command->firstContentType ?? false;
 $allowMissingDocs = $command->allowMissingDocs ?? false;
 $useTags = $command->tags ?? true;
-Logger::$exitOnError = !($command->continueOnError ?? false);
 Logger::$verbose = $command->verbose ?? false;
 $openapiVersion = $command->openapiVersion ?? '3.0.3';
 
@@ -1025,4 +1023,8 @@ foreach ($scopePaths as $scope => $paths) {
 	file_put_contents($scopeOut, json_encode($openapiScope, Helpers::jsonFlags()) . "\n");
 
 	Logger::info('app', 'Generated scope ' . $scope . ' with ' . $pathsCount . ' routes!');
+}
+
+if (Logger::$errorCount > 0) {
+	Logger::panic('app', 'Encountered ' . Logger::$errorCount . ' errors that need to be fixed!');
 }

--- a/merge-specs
+++ b/merge-specs
@@ -171,3 +171,7 @@ function rewriteOperations(array $spec): array {
 }
 
 file_put_contents($mergedSpecPath, json_encode($data, Helpers::jsonFlags()) . "\n");
+
+if (Logger::$errorCount > 0) {
+	Logger::panic('app', 'Encountered ' . Logger::$errorCount . ' errors that need to be fixed!');
+}

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -3,8 +3,8 @@
 namespace OpenAPIExtractor;
 
 class Logger {
-	public static bool $exitOnError = true;
 	public static bool $verbose = false;
+	public static int $errorCount = 0;
 
 	protected static function log(LoggerLevel $level, string $context, string $text): void {
 		print(self::format($level, $context, $text));
@@ -34,15 +34,9 @@ class Logger {
 		self::log(LoggerLevel::Warning, $context, $text);
 	}
 
-	/**
-	 * @throws LoggerException
-	 */
 	public static function error(string $context, string $text): void {
-		if (self::$exitOnError) {
-			throw new LoggerException(LoggerLevel::Error, $context, $text);
-		} else {
-			self::log(LoggerLevel::Error, $context, $text);
-		}
+		self::$errorCount++;
+		self::log(LoggerLevel::Error, $context, $text);
 	}
 
 	/**


### PR DESCRIPTION
While this flag was meant to speed up development, people are starting to abuse it any ignore any errors.
They won't even know that the spec isn't complete due to all the errors.