### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2024-08-20
+
+### Added
+
+- Initial stable release

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
 	"name": "nextcloud/openapi-extractor",
+	"description": "A tool for extracting OpenAPI specifications from Nextcloud source code",
+	"license": "AGPL-3.0-or-later",
 	"bin": [
 		"generate-spec",
 		"merge-specs"


### PR DESCRIPTION
As far as I understand the `version` field can be left empty since we are going to use git tags to denote the version: https://getcomposer.org/doc/04-schema.md#version