### PR TITLE
fix(OCS): Fix route vs Controller differences

### DIFF
--- a/generate-spec
+++ b/generate-spec
@@ -334,12 +334,11 @@ if (count($parsedRoutes) === 0) {
 $operationIds = [];
 
 foreach ($parsedRoutes as $key => $value) {
-	$isOCS = $key === 'ocs';
-	$isIndex = $key === 'routes';
-
-	if (!$isOCS && !$isIndex) {
-		continue;
-	}
+	$pathPrefix = match ($key) {
+		'ocs' => '/ocs/v2.php',
+		'routes' => '/index.php',
+		default => throw new \InvalidArgumentException('Unknown routes key "' . $key . '"'),
+	};
 
 	foreach ($value as $route) {
 		$routeName = $route['name'];
@@ -356,12 +355,7 @@ foreach ($parsedRoutes as $key => $value) {
 		if (str_ends_with($url, '/')) {
 			$url = substr($url, 0, -1);
 		}
-		if ($isIndex) {
-			$url = '/index.php' . $root . $url;
-		}
-		if ($isOCS) {
-			$url = '/ocs/v2.php' . $root . $url;
-		}
+		$url = $pathPrefix . $root . $url;
 
 		$methodName = lcfirst(str_replace('_', '', ucwords(explode('#', $routeName)[1], '_')));
 		if ($methodName == 'preflightedCors') {
@@ -380,6 +374,18 @@ foreach ($parsedRoutes as $key => $value) {
 		if ($controllerClass == null) {
 			Logger::error($routeName, "Controller '" . $controllerName . "' not found");
 			continue;
+		}
+
+		$parentControllerClass = $controllerClass->extends?->name ?? '';
+		$parentControllerClass = explode('\\', $parentControllerClass);
+		$parentControllerClass = end($parentControllerClass);
+		// This is very ugly, but since we do not parse the entire source code we can not say with certainty which controller type is used.
+		// To still allow apps to use custom controllers that extend OCSController, we only check the suffix and have the warning if the controller type can not be detected.
+		$isOCS = str_ends_with($parentControllerClass, 'OCSController');
+		if ($parentControllerClass !== 'Controller' && $parentControllerClass !== 'ApiController' && $parentControllerClass !== 'OCSController' && !$isOCS) {
+			Logger::warning($routeName, 'You are extending a custom controller class. Make sure that it ends with "OCSController" if it extends "OCSController" itself.');
+		} elseif ($isOCS !== ($pathPrefix === '/ocs/v2.php')) {
+			Logger::warning($routeName, 'Do not mix OCS/non-OCS routes and non-OCS/OCS controllers!');
 		}
 
 		$controllerScopes = Helpers::getOpenAPIAttributeScopes($controllerClass, $routeName);

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -4625,6 +4625,16 @@
                             "pattern": "^[a-z]+$",
                             "default": "abc"
                         }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
                     }
                 ],
                 "responses": {
@@ -4632,7 +4642,27 @@
                         "description": "Success",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -4663,6 +4693,16 @@
                             "pattern": "^[a-z]+$",
                             "default": "abc"
                         }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
                     }
                 ],
                 "responses": {
@@ -4670,7 +4710,27 @@
                         "description": "Success",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -4718,7 +4778,27 @@
                         "description": "Success",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -4775,6 +4775,16 @@
                             "pattern": "^[a-z]+$",
                             "default": "abc"
                         }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
                     }
                 ],
                 "responses": {
@@ -4782,7 +4792,27 @@
                         "description": "Success",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -4813,6 +4843,16 @@
                             "pattern": "^[a-z]+$",
                             "default": "abc"
                         }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
                     }
                 ],
                 "responses": {
@@ -4820,7 +4860,27 @@
                         "description": "Success",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -4868,7 +4928,27 @@
                         "description": "Success",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The route key controls the path and the extended class controls the response.
Any sane API would not mix these, but Groupfolders does so anyway :melting_face:
The assumption that these are always the same is not given, thus we need to properly handle it...
We actually already had some test endpoints that triggered this case, but until now generated the wrong documentation (without the OCS wrap).