### PR TITLE
feat(generate-spec): Ignore index.php routes by default

### DIFF
--- a/generate-spec.php
+++ b/generate-spec.php
@@ -463,15 +463,6 @@ foreach ($parsedRoutes as $key => $value) {
 			Logger::panic($routeName, 'Route is marked as ignore but also has other scopes');
 		}
 
-		if (in_array('ignore', $scopes, true)) {
-			if (count($scopes) === 1) {
-				Logger::debug($routeName, 'Route ignored because of OpenAPI attribute');
-				continue;
-			}
-
-			Logger::panic($routeName, 'Route is marked as ignore but also has other scopes');
-		}
-
 		if ($scopes === []) {
 			if ($controllerScopes !== []) {
 				$scopes = $controllerScopes;
@@ -482,6 +473,15 @@ foreach ($parsedRoutes as $key => $value) {
 			} else {
 				$scopes = ['default'];
 			}
+		}
+
+		if (in_array('ignore', $scopes, true)) {
+			if (count($scopes) === 1) {
+				Logger::debug($routeName, 'Route ignored because of OpenAPI attribute');
+				continue;
+			}
+
+			Logger::panic($routeName, 'Route is marked as ignore but also has other scopes');
 		}
 
 		$routeTags = Helpers::getOpenAPIAttributeTagsByScope($classMethod, $routeName, $tagName, reset($scopes));

--- a/generate-spec.php
+++ b/generate-spec.php
@@ -466,6 +466,8 @@ foreach ($parsedRoutes as $key => $value) {
 		if ($scopes === []) {
 			if ($controllerScopes !== []) {
 				$scopes = $controllerScopes;
+			} elseif (!$isOCS) {
+				$scopes = ['ignore'];
 			} elseif ($isExApp) {
 				$scopes = ['ex_app'];
 			} elseif ($isAdmin) {

--- a/tests/lib/Controller/PlainController.php
+++ b/tests/lib/Controller/PlainController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Notifications\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Response;
+
+class PlainController extends Controller {
+	#[NoCSRFRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/plain/ignored')]
+	public function ignored(): Response {
+		return new Response();
+	}
+
+
+	/**
+	 * Route with manual scope to not get ignored
+	 *
+	 * @return Response<Http::STATUS_OK, array{}>
+	 *
+	 * 200: Response returned
+	 */
+	#[NoCSRFRequired]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
+	#[FrontpageRoute(verb: 'GET', url: '/plain/with-scope')]
+	public function withScope(): Response {
+		return new Response();
+	}
+}

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -5485,6 +5485,29 @@
                 }
             }
         },
+        "/index.php/apps/notifications/plain/with-scope": {
+            "get": {
+                "operationId": "plain-with-scope",
+                "summary": "Route with manual scope to not get ignored",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "plain"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Response returned"
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/ex-app-attribute": {
             "post": {
                 "operationId": "ex_app_settings-ex-app-scope-attribute",

--- a/tests/openapi.json
+++ b/tests/openapi.json
@@ -797,6 +797,29 @@
                     }
                 }
             }
+        },
+        "/index.php/apps/notifications/plain/with-scope": {
+            "get": {
+                "operationId": "plain-with-scope",
+                "summary": "Route with manual scope to not get ignored",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "plain"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Response returned"
+                    }
+                }
+            }
         }
     },
     "tags": []


### PR DESCRIPTION
index.php routes are not meant to be used for stable APIs.
Unfortunately we have a lot of legacy APIs that still use them so we can't just ignore them entirely.
This changes the default behavior to ignore them, but one can still manually include them by changing the scope for a method or controller.