### PR TITLE
fix(merge-specs): Use objects instead of associative arrays to fix empty JSON objects

### DIFF
--- a/.github/workflows/test-repositories.yml
+++ b/.github/workflows/test-repositories.yml
@@ -76,11 +76,24 @@ jobs:
         if: matrix.repositories == 'nextcloud/server'
         working-directory: temp-repository/
         run: |
+          specs=()
           for path in core apps/*; do
             if [ ! -f "$path/.noopenapi" ]; then
               ../bin/generate-spec "$path" "$path/openapi.json" || exit 1
+              if [[ "$(basename "$path")" != "core" ]]; then
+                if [ -f "$path/openapi-full.json" ]; then
+                  specs+=("$path/openapi-full.json")
+                else
+                  specs+=("$path/openapi.json")
+                fi
+              fi
             fi
           done
+
+          ../bin/merge-specs \
+            --core core/openapi-full.json \
+            --merged openapi.json \
+            "${specs[@]}"
 
       - name: Show changes of the API for assistance
         working-directory: temp-repository/


### PR DESCRIPTION
https://github.com/nextcloud/openapi-extractor/issues/225

Otherwise `{}` from JSON will turn into `[]` in PHP and then into `[]` in JSON which is not valid.