### PR TITLE
fix(ControllerMethod): Log an error if return statements are detected but no @return annotation is present

### DIFF
--- a/generate-spec.php
+++ b/generate-spec.php
@@ -520,10 +520,6 @@ foreach ($parsedRoutes as $key => $value) {
 		}
 
 		$classMethodInfo = ControllerMethod::parse($routeName, $definitions, $methodFunction, $isAdmin, $isDeprecated, $isPasswordConfirmation, $isCORS);
-		if ($classMethodInfo->returns !== []) {
-			Logger::error($routeName, 'Returns an invalid response');
-			continue;
-		}
 		if (count($classMethodInfo->responses) == 0) {
 			Logger::error($routeName, 'Returns no responses');
 			continue;

--- a/src/ControllerMethod.php
+++ b/src/ControllerMethod.php
@@ -8,6 +8,7 @@
 namespace OpenAPIExtractor;
 
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\DeprecatedTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
@@ -45,7 +46,7 @@ class ControllerMethod {
 		bool $isPasswordConfirmation,
 		bool $isCORS,
 	): ControllerMethod {
-		global $phpDocParser, $lexer, $allowMissingDocs;
+		global $phpDocParser, $lexer, $nodeFinder, $allowMissingDocs;
 
 		$parameters = [];
 		$responses = [];
@@ -55,6 +56,9 @@ class ControllerMethod {
 		$methodSummary = null;
 		$methodParameters = $method->getParams();
 		$docParameters = [];
+
+		$returnStmtCount = count($nodeFinder->findInstanceOf($method->getStmts(), Return_::class));
+		$returnTagCount = 0;
 
 		$doc = $method->getDocComment()?->getText();
 		if ($doc !== null) {
@@ -109,6 +113,8 @@ class ControllerMethod {
 					}
 
 					if ($docNode->value instanceof ReturnTagValueNode) {
+						$returnTagCount++;
+
 						$type = $docNode->value->type;
 
 						$responses = array_merge($responses, ResponseType::resolve($context . ': @return', $type));
@@ -134,6 +140,10 @@ class ControllerMethod {
 					}
 				}
 			}
+		}
+
+		if ($returnStmtCount !== 0 && $returnTagCount === 0) {
+			Logger::error($context, 'Missing @return annotation');
 		}
 
 		if (!$allowMissingDocs) {

--- a/src/ControllerMethod.php
+++ b/src/ControllerMethod.php
@@ -30,7 +30,6 @@ class ControllerMethod {
 	public function __construct(
 		public array $parameters,
 		public array $responses,
-		public array $returns,
 		public array $responseDescription,
 		public array $description,
 		public ?string $summary,
@@ -51,7 +50,6 @@ class ControllerMethod {
 		$parameters = [];
 		$responses = [];
 		$responseDescriptions = [];
-		$returns = [];
 
 		$methodDescription = [];
 		$methodSummary = null;
@@ -266,7 +264,7 @@ class ControllerMethod {
 			Logger::warning($context, 'Summary ends with a punctuation mark');
 		}
 
-		return new ControllerMethod($parameters, $responses, $returns, $responseDescriptions, $methodDescription, $methodSummary, $isDeprecated);
+		return new ControllerMethod($parameters, $responses, $responseDescriptions, $methodDescription, $methodSummary, $isDeprecated);
 	}
 
 }


### PR DESCRIPTION
We already log an error if no response is returned from a controller method, but that is also satisfied if a `@throws` annotation is present.
Luckily with the return statements we can easily check if any is present (there might be controller methods that only throw or never return), so a separate error is now logged in case the code has a `return` statement but no `@return` annotation.