### PR TITLE
feat(ControllerMethod): Parse request headers

### DIFF
--- a/generate-spec.php
+++ b/generate-spec.php
@@ -838,6 +838,20 @@ foreach ($routes as $scope => $scopeRoutes) {
 
 			$parameters[] = $parameter;
 		}
+
+		foreach ($route->controllerMethod->requestHeaders as $requestHeader) {
+			$parameters[] = [
+				'name' => $requestHeader,
+				'in' => 'header',
+				// Not required, because getHeader() will return an empty string by default.
+				// It might still mean that a header is always required, but the controller method has to check the
+				// value manually anyway.
+				'schema' => [
+					'type' => 'string',
+				],
+			];
+		}
+
 		if ($route->isOCS || !$route->isNoCSRFRequired) {
 			$parameters[] = [
 				'name' => 'OCS-APIRequest',

--- a/tests/appinfo/routes.php
+++ b/tests/appinfo/routes.php
@@ -85,6 +85,7 @@ return [
 		['name' => 'Settings#deprecatedRouteAndParameterGet', 'url' => '/api/{apiVersion}/deprecated-route-parameter-get', 'verb' => 'GET', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#samePathGet', 'url' => '/api/{apiVersion}/same-path', 'verb' => 'GET', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#samePathPost', 'url' => '/api/{apiVersion}/same-path', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
+		['name' => 'Settings#requestHeader', 'url' => '/api/{apiVersion}/request-header', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'V1\SubDir#subDirRoute', 'url' => '/sub-dir', 'verb' => 'GET'],
 	],
 ];

--- a/tests/lib/Controller/SettingsController.php
+++ b/tests/lib/Controller/SettingsController.php
@@ -739,4 +739,17 @@ class SettingsController extends OCSController {
 	public function samePathPost(): DataResponse {
 		return new DataResponse();
 	}
+
+	/**
+	 * A method with a request header.
+	 *
+	 * @return DataResponse<Http::STATUS_OK, list<empty>, array{}>
+	 *
+	 * 200: Admin settings updated
+	 */
+	public function requestHeader(): DataResponse {
+		$value = $this->request->getHeader('X-Custom-Header');
+
+		return new DataResponse();
+	}
 }

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -5352,6 +5352,85 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/request-header": {
+            "post": {
+                "operationId": "settings-request-header",
+                "summary": "A method with a request header.",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "X-Custom-Header",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Admin settings updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/tests/attribute-ocs/{param}": {
             "get": {
                 "operationId": "routing-attributeocs-route",

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -5509,6 +5509,85 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion}/request-header": {
+            "post": {
+                "operationId": "settings-request-header",
+                "summary": "A method with a request header.",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v2"
+                            ],
+                            "default": "v2"
+                        }
+                    },
+                    {
+                        "name": "X-Custom-Header",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Admin settings updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/tests/attribute-ocs/{param}": {
             "get": {
                 "operationId": "routing-attributeocs-route",


### PR DESCRIPTION
If the getHeader() call is not directly in the controller method we can't detect that, but better than parsing nothing at all.

https://github.com/nextcloud/openapi-extractor/issues/89