### PR TITLE
fix: Return type of StreamTraversableResponse

### DIFF
--- a/src/ResponseType.php
+++ b/src/ResponseType.php
@@ -140,7 +140,7 @@ class ResponseType {
 				false,
 				false,
 				null,
-				null,
+				$binaryType,
 				null,
 			),
 			new ResponseType(

--- a/tests/openapi-administration.json
+++ b/tests/openapi-administration.json
@@ -10134,7 +10134,15 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Export OK"
+                        "description": "Export OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
                     },
                     "401": {
                         "description": "Current user is not logged in",

--- a/tests/openapi-full.json
+++ b/tests/openapi-full.json
@@ -10334,7 +10334,15 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Export OK"
+                        "description": "Export OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
                     },
                     "401": {
                         "description": "Current user is not logged in",


### PR DESCRIPTION
We should ideally use the new features from
https://bump.sh/blog/json-streaming-openapi-3-2/ but this requires some changes in server.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
